### PR TITLE
Float left proof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.idea
+/public
+_gen/

--- a/content/post/2015-02-20-test-markdown.md
+++ b/content/post/2015-02-20-test-markdown.md
@@ -23,7 +23,11 @@ Here's a useless table:
 
 How about a yummy crepe?
 
-![Crepe](http://s3-media3.fl.yelpcdn.com/bphoto/cQ1Yoa75m2yUFFbY2xwuqw/348s.jpg)
+![.pull-left|Crepe](http://s3-media3.fl.yelpcdn.com/bphoto/cQ1Yoa75m2yUFFbY2xwuqw/348s.jpg)
+
+Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.
+
+The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.
 
 Here's a code chunk with syntax highlighting:
 

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,0 +1,12 @@
+{{ $text := .Text }}
+{{ $parts := split .Text "|"}}
+{{ $isClass := hasPrefix $text "." }}
+{{ $hasMeta := eq (len $parts) 2}}
+{{ $class := ""}}
+{{ if and $isClass $hasMeta }}
+    {{ $class = index $parts 0 | strings.TrimLeft "." }}
+    {{ $text = index $parts 1 }}
+{{ end }}
+<p{{ with $class}} class="{{ $class }}"{{ end }}>
+<img src="{{ .Destination | safeURL }}" alt="{{ $text }}" {{ with .Title }} title="{{ .Title }}"{{ end }} />
+</p>


### PR DESCRIPTION
The idea is to use [Hugo's markdown render hooks](https://gohugo.io/templates/render-hooks/) to customise how an image is displayed with markdown.

We co-opt the alt text to allow us to add custom class name to the image. This way we can choose to float left, or right or put the image in the middle of the page or whatever. If the alt text starts with `.` and has a single `|` character, take the text between the `.` and `|` and use it as a class for the paragraph.

Usually you'd also want to run some regex validation on the text to make sure it's a valid classname and prevent DOM injection, but since its just generating static content, there's not the same need for security.

`.pull-left` is the old bootstrap class intended to add `float:left;`

Looks like this template is using a very old version of bootstrap, which might not be well documented, and can be especially painful to deal with. Might be tempted to start from scratch if I find the time one day.